### PR TITLE
feat: publish pdal base image TDE-2049

### DIFF
--- a/.github/workflows/publish-pdal-base.yml
+++ b/.github/workflows/publish-pdal-base.yml
@@ -1,0 +1,58 @@
+name: Publish PDAL base image
+
+# Builds the PDAL runtime that Dockerfile.pointcloud starts from, so that a release of this
+# repository can pull a cached layer instead of recompiling PDAL.
+# Only runs when the recipe changes, or on request.
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - "Dockerfile.pdal"
+      - ".github/workflows/publish-pdal-base.yml"
+  workflow_dispatch:
+
+jobs:
+  publish-pdal-base:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read the PDAL version from the recipe
+        id: pdal
+        run: |
+          version="$(sed -n 's/^ARG PDAL_VERSION=//p' Dockerfile.pdal)"
+          if [[ -z "$version" ]]; then echo "PDAL_VERSION not found in Dockerfile.pdal" >&2; exit 1; fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile.pdal
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/pdal:${{ steps.pdal.outputs.version }}
+
+      - name: Report the reference to pin
+        run: |
+          {
+            echo "Update the FROM lines in Dockerfile.pointcloud to:"
+            echo '```'
+            echo "ghcr.io/${{ github.repository_owner }}/pdal:${{ steps.pdal.outputs.version }}@${{ steps.build.outputs.digest }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile.pdal
+++ b/Dockerfile.pdal
@@ -1,5 +1,5 @@
 # A PDAL runtime, built from source and published as `ghcr.io/linz/pdal:<version>` so that
-# routine releases of this repository does not have to recompile it.
+# a new release of this repository does not have to recompile it.
 # Rebuilt only when this file changes.
 #
 ARG PDAL_VERSION=2.10.2
@@ -15,31 +15,31 @@ ENV TZ=Etc/UTC
 ARG PDAL_VERSION
 ARG PDAL_COMMIT
 
-# Install build dependencies. No plugin is enabled, so only the libraries core PDAL links
-# against are needed: the LAS, LAZ and COPC drivers are built in.
+# Install build dependencies.
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
     build-essential \
     ca-certificates \
     cmake \
     git \
+    libcurl4-openssl-dev \
     libgdal-dev \
-    libgeos-dev \
     libgeotiff-dev \
-    liblaszip-dev \
+    libgtest-dev \
     libproj-dev \
-    libtiff-dev \
-    libzstd-dev \
+    ninja-build \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 --branch "$PDAL_VERSION" https://github.com/PDAL/PDAL.git /usr/src/pdal
 RUN test "$(git -C /usr/src/pdal rev-parse HEAD)" = "$PDAL_COMMIT"
 
-# /usr/local/lib is already on the loader path, so no RPATH handling is needed
+# Ninja as used by PDAL CI.
 RUN cmake -S /usr/src/pdal -B /usr/src/pdal/build \
+    -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DUSE_EXTERNAL_GTEST=ON \
     -DWITH_TESTS=OFF
 RUN cmake --build /usr/src/pdal/build --parallel "$(nproc)"
 RUN cmake --install /usr/src/pdal/build
@@ -51,18 +51,15 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV TZ=Etc/UTC
 
-# PDAL links against the distribution's GDAL, PROJ, GEOS and laszip, so the runtime needs their
-# shared libraries. PROJ and GDAL find their own data under /usr/share, so no PROJ_DATA or
-# GDAL_DATA is required. python3 runs the environments layered on top of this image, and
-# ca-certificates is needed to reach S3.
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         ca-certificates \
         libgdal34t64 \
-        liblaszip8 \
         python3 \
     && rm -rf /var/lib/apt/lists/*
 
+# BSD clause 2: binary redistribution must reproduce the licence.
+COPY --from=builder /usr/src/pdal/LICENSE.txt /usr/share/doc/pdal/copyright
 COPY --from=builder /usr/local/bin/pdal /usr/local/bin/pdal
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
 RUN ldconfig \

--- a/Dockerfile.pdal
+++ b/Dockerfile.pdal
@@ -1,0 +1,76 @@
+# A PDAL runtime, built from source and published as `ghcr.io/linz/pdal:<version>` so that
+# routine releases of this repository does not have to recompile it.
+# Rebuilt only when this file changes.
+#
+ARG PDAL_VERSION=2.10.2
+ARG PDAL_COMMIT=27008f6241be44585c866a29dfc13bb16d678dab
+
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS builder
+
+# Avoid blocking `apt-get install` commands
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV TZ=Etc/UTC
+
+ARG PDAL_VERSION
+ARG PDAL_COMMIT
+
+# Install build dependencies. No plugin is enabled, so only the libraries core PDAL links
+# against are needed: the LAS, LAZ and COPC drivers are built in.
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    git \
+    libgdal-dev \
+    libgeos-dev \
+    libgeotiff-dev \
+    liblaszip-dev \
+    libproj-dev \
+    libtiff-dev \
+    libzstd-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch "$PDAL_VERSION" https://github.com/PDAL/PDAL.git /usr/src/pdal
+RUN test "$(git -C /usr/src/pdal rev-parse HEAD)" = "$PDAL_COMMIT"
+
+# /usr/local/lib is already on the loader path, so no RPATH handling is needed
+RUN cmake -S /usr/src/pdal -B /usr/src/pdal/build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DWITH_TESTS=OFF
+RUN cmake --build /usr/src/pdal/build --parallel "$(nproc)"
+RUN cmake --install /usr/src/pdal/build
+
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+# Avoid blocking `apt-get install` commands
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV TZ=Etc/UTC
+
+# PDAL links against the distribution's GDAL, PROJ, GEOS and laszip, so the runtime needs their
+# shared libraries. PROJ and GDAL find their own data under /usr/share, so no PROJ_DATA or
+# GDAL_DATA is required. python3 runs the environments layered on top of this image, and
+# ca-certificates is needed to reach S3.
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends \
+        ca-certificates \
+        libgdal34t64 \
+        liblaszip8 \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/pdal /usr/local/bin/pdal
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+RUN ldconfig \
+    && ! ldd /usr/local/bin/pdal | grep -q 'not found' \
+    && pdal --version
+
+ARG PDAL_VERSION
+ARG PDAL_COMMIT
+LABEL nz.govt.linz.pdal.version="$PDAL_VERSION"
+LABEL nz.govt.linz.pdal.commit="$PDAL_COMMIT"
+LABEL nz.govt.linz.pdal.source="built-from-source"

--- a/Dockerfile.pdal
+++ b/Dockerfile.pdal
@@ -22,7 +22,6 @@ RUN apt-get update \
     ca-certificates \
     cmake \
     git \
-    libcurl4-openssl-dev \
     libgdal-dev \
     libgeotiff-dev \
     libgtest-dev \


### PR DESCRIPTION
### Motivation

Publish a PDAL image so we do not have to pull their large image or re-build each time we want to create a new image of our pointcloud scripts.

### Modifications

Added workflow to build PDAL docker image when the respective Dockerfile or workflow changes.

### Verification

Manual test runs.
