### PR TITLE
feat: investigate using data type parameter for bigtiffs tde-2034

### DIFF
--- a/packages/topo-imagery-stac/src/topo_imagery_stac/imagery/collection.py
+++ b/packages/topo-imagery-stac/src/topo_imagery_stac/imagery/collection.py
@@ -121,6 +121,9 @@ class ImageryCollection:
             "updated": updated_datetime,
         }
 
+        if context.data_type:
+            self.stac["data_type"] = context.data_type
+
         # Optional metadata - if not provided, the field will not be added to the Collection
         if event_name := context.event_name:
             self.stac["linz:event_name"] = event_name
@@ -164,6 +167,10 @@ class ImageryCollection:
             updated_datetime: The updated datetime of the Collection.
         """
         self.stac["gsd"] = float(context.gsd)
+        if context.data_type:
+            self.stac["data_type"] = context.data_type
+        else:
+            self.stac.pop("data_type", None)
         self.stac["linz:security_classification"] = "unclassified"
         if context.lifecycle:
             self.stac["linz:lifecycle"] = context.lifecycle

--- a/packages/topo-imagery-stac/src/topo_imagery_stac/imagery/collection_context.py
+++ b/packages/topo-imagery-stac/src/topo_imagery_stac/imagery/collection_context.py
@@ -21,6 +21,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
         domain (str): The domain of the dataset (e.g., "land").
         region (str): The region of the dataset (e.g., "auckland").
         gsd (Decimal): Ground Sample Distance in meters.
+        data_type (str): The data type of the dataset (e.g., "uint16").
         lifecycle (str): Lifecycle status of the dataset (e.g., "completed").
         linz_slug (str): LINZ slug for the dataset.
         producers (list[str]): List of producers for the dataset.
@@ -42,6 +43,7 @@ class CollectionContext:  # pylint:disable=too-many-instance-attributes
     gsd: Decimal
     lifecycle: str
     linz_slug: str
+    data_type: str = ""
     producers: list[str] = field(default_factory=list)
     licensors: list[str] = field(default_factory=list)
     collection_id: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,15 @@ line_length = 127
 case_sensitive = true
 profile = "black"
 
+[tool.pytest.ini_options]
+pythonpath = [
+    "packages/topo-imagery-common/test",
+    "packages/topo-imagery-gdal/test",
+    "packages/topo-imagery-pdal/test",
+    "packages/topo-imagery-stac/test",
+    "scripts/tests",
+]
+
 [tool.mypy]
 show_error_codes = true
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,15 +61,6 @@ line_length = 127
 case_sensitive = true
 profile = "black"
 
-[tool.pytest.ini_options]
-pythonpath = [
-    "packages/topo-imagery-common/test",
-    "packages/topo-imagery-gdal/test",
-    "packages/topo-imagery-pdal/test",
-    "packages/topo-imagery-stac/test",
-    "scripts/tests",
-]
-
 [tool.mypy]
 show_error_codes = true
 strict = true

--- a/scripts/collection_from_items.py
+++ b/scripts/collection_from_items.py
@@ -73,6 +73,13 @@ def get_args_parser() -> CommonArgumentParser:
     )
     parser.add_argument("--gsd", dest="gsd", help="GSD of imagery Dataset, for example 0.3", type=str_to_gsd, required=True)
     parser.add_argument(
+        "--data-type",
+        dest="data_type",
+        help="Dataset data type, e.g. uint16, uint32, float32",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
         "--geographic-description",
         dest="geographic_description",
         help="Optional Geographic Description of dataset, e.g. Hutt City",
@@ -262,6 +269,7 @@ def main(args: List[str] | None = None) -> None:
         domain=arguments.domain,
         region=arguments.region,
         gsd=arguments.gsd,
+        data_type=arguments.data_type,
         lifecycle=arguments.lifecycle,
         linz_slug=arguments.linz_slug,
         collection_id=collection_id,

--- a/scripts/tests/collection_from_items_test.py
+++ b/scripts/tests/collection_from_items_test.py
@@ -62,6 +62,8 @@ def test_should_create_collection_file(item: ImageryItem, fake_collection_contex
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -102,6 +104,8 @@ def test_should_create_coastal_collection_file(item: ImageryItem, fake_collectio
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -119,6 +123,46 @@ def test_should_create_coastal_collection_file(item: ImageryItem, fake_collectio
     # Verify collection.json has been created with "Coastal" information
     resp = s3_client.get_object(Bucket="stacfiles", Key="collection.json")
     assert "Coastal" in resp["Body"].read().decode("utf-8")
+
+
+@mock_aws
+def test_should_store_data_type_on_collection_only(item: ImageryItem, fake_collection_context: CollectionContext) -> None:
+    s3_client: S3Client = client("s3", region_name=DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="stacfiles")
+    item.add_collection("abc")
+    write("s3://stacfiles/item.json", dict_to_json_bytes(item.stac))
+
+    args = [
+        "--uri",
+        "s3://stacfiles/",
+        "--collection-id",
+        "abc",
+        "--category",
+        "urban-aerial-photos",
+        "--region",
+        "hawkes-bay",
+        "--gsd",
+        "1",
+        "--data-type",
+        "uint16",
+        "--lifecycle",
+        "ongoing",
+        "--producer",
+        "Placeholder",
+        "--licensor",
+        "Placeholder",
+        "--concurrency",
+        "25",
+        "--linz-slug",
+        fake_collection_context.linz_slug,
+    ]
+
+    main(args)
+
+    resp = s3_client.get_object(Bucket="stacfiles", Key="collection.json")
+    collection = json.loads(resp["Body"].read().decode("utf-8"))
+    assert collection["data_type"] == "uint16"
+    assert "data_type" not in item.stac
 
 
 @mock_aws
@@ -145,6 +189,8 @@ def test_should_fail_if_collection_has_no_matching_items(
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -182,6 +228,8 @@ def test_should_fail_to_create_collection_file_without_linz_slug(capsys: Capture
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -218,6 +266,8 @@ def test_should_not_add_if_not_item(fake_collection_context: CollectionContext, 
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -261,6 +311,8 @@ def test_should_determine_dates_from_items(item: ImageryItem, fake_collection_co
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -322,6 +374,8 @@ def test_should_accept_simplified_capture_area_flag(item: ImageryItem, fake_coll
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -373,6 +427,8 @@ def test_should_fail_with_both_supplied_and_simplified_capture_area(
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -419,6 +475,8 @@ def test_should_fail_with_both_supplied_capture_area_and_capture_dates(
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -483,6 +541,8 @@ def test_should_pass_with_empty_supplied_capture_area_and_capture_dates(
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -566,6 +626,8 @@ def test_should_use_capture_dates_for_capture_area(item: ImageryItem, fake_colle
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",
@@ -608,6 +670,8 @@ def test_should_fail_when_capture_dates_file_missing(
         "hawkes-bay",
         "--gsd",
         "1",
+        "--data-type",
+        "uint16",
         "--lifecycle",
         "ongoing",
         "--producer",


### PR DESCRIPTION
### Motivation

Investigate using new data_type parameter for identifying 16/32-bit data in topo-imagery

### Modifications

Used the data-type parameter for simplification as there is no need to read from the tiff because stac-setup and tileindex are already checking the bit depth. 


